### PR TITLE
Interactions support

### DIFF
--- a/polecen-macros/Cargo.toml
+++ b/polecen-macros/Cargo.toml
@@ -11,9 +11,10 @@ repository = "https://github.com/Unoqwy/polecen"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.26"
-syn = { version = "1.0.72", features = ["full"] }
-quote = "1.0.9"
+proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+
 convert_case = "0.4.0"
 
 [features]

--- a/polecen-macros/Cargo.toml
+++ b/polecen-macros/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro2 = "1.0.26"
 syn = { version = "1.0.72", features = ["full"] }
 quote = "1.0.9"
 convert_case = "0.4.0"
+
+[features]
+interactions = []

--- a/polecen/Cargo.toml
+++ b/polecen/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 polecen-macros = { path = "../polecen-macros", optional = true }
 
 serde = "1.0"
+serde_json = { version =  "1.0", optional = true }
 
 async-trait = "0.1"
 humantime = { version = "2.0", optional = true }
@@ -26,7 +27,7 @@ default = ["serenity_rustls", "polecen_default"]
 
 polecen_default = ["macros", "default_parsers"]
 macros = ["polecen-macros"]
-interactions = ["serenity/unstable_discord_api", "polecen-macros/interactions"]
+interactions = ["serenity/unstable_discord_api", "polecen-macros/interactions", "serde_json"]
 
 default_parsers = ["default_parsers_primitives", "default_parsers_models", "default_parsers_time"]
 

--- a/polecen/Cargo.toml
+++ b/polecen/Cargo.toml
@@ -26,6 +26,7 @@ default = ["serenity_rustls", "polecen_default"]
 
 polecen_default = ["macros", "default_parsers"]
 macros = ["polecen-macros"]
+interactions = ["serenity/unstable_discord_api", "polecen-macros/interactions"]
 
 default_parsers = ["default_parsers_primitives", "default_parsers_models", "default_parsers_time"]
 

--- a/polecen/src/arguments/default.rs
+++ b/polecen/src/arguments/default.rs
@@ -21,17 +21,30 @@ macro_rules! default_impl {
             }
         }
     };
-    ($($ty:ty $(=> $into:ty)?),+) => {
-        $( default_impl!(> $ty, _ctx, raw $(=> $into)?); )+
+    ($raw:ident) => {
+        (match $raw {
+            ArgumentParseRaw::String(value) => value.parse(),
+            #[cfg(feature = "interactions")]
+            ArgumentParseRaw::InteractionData(serde_json::Value::String(value)) => value.parse(),
+            #[cfg(feature = "interactions")]
+            // FIXME: get numerical value from Number directly instead of using to_string
+            ArgumentParseRaw::InteractionData(serde_json::Value::Number(value)) => value.to_string().parse(),
+            #[cfg(feature = "interactions")]
+            _ => return Err(ArgumentParseError::InvalidValueFormat)
+        }).map_err(|_| ArgumentParseError::InvalidValueFormat)
+    };
+    ($($ty:ty $(=> $middleman:ty)?),+) => {
+        $( default_impl!(> $ty, _ctx, raw $(=> $middleman)?); )+
     };
     (> $ty:ty, $ctx:ident, $raw:ident) => {
         default_impl!($ty, $ctx, $raw, {
-            Ok($raw.value.parse().map_err(|_| ArgumentParseError::InvalidValueFormat)?)
+            Ok(default_impl!($raw)?)
         });
     };
-    (> $ty:ty, $ctx:ident, $raw:ident => $into:ty) => {
+    (> $ty:ty, $ctx:ident, $raw:ident => $middleman:ty) => {
         default_impl!($ty, $ctx, $raw, {
-            Ok($raw.value.parse::<$into>().map_err(|_| ArgumentParseError::InvalidValueFormat)?.into())
+            let value: $middleman = default_impl!($raw)?;
+            Ok(value.into())
         });
     };
 }
@@ -48,13 +61,35 @@ mod primitives {
             _ctx: &ArgumentParseContext<'a>,
             raw: ArgumentParseRaw,
         ) -> Result<Self, ArgumentParseError> {
-            Ok(raw.value)
+            match raw {
+                ArgumentParseRaw::String(value) => Ok(value),
+                #[cfg(feature = "interactions")]
+                ArgumentParseRaw::InteractionData(serde_json::Value::String(value)) => Ok(value),
+                #[cfg(feature = "interactions")]
+                _ => Err(ArgumentParseError::InvalidValueType),
+            }
         }
     }
 
-    default_impl!(
-        bool, char, f32, f64, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
-    );
+    #[async_trait]
+    impl ArgumentType for bool {
+        async fn parse_argument<'a>(
+            _ctx: &ArgumentParseContext<'a>,
+            raw: ArgumentParseRaw,
+        ) -> Result<Self, ArgumentParseError> {
+            match raw {
+                ArgumentParseRaw::String(value) => {
+                    Ok(value.parse().map_err(|_| ArgumentParseError::InvalidValueFormat)?)
+                },
+                #[cfg(feature = "interactions")]
+                ArgumentParseRaw::InteractionData(serde_json::Value::Bool(value)) => Ok(value),
+                #[cfg(feature = "interactions")]
+                _ => Err(ArgumentParseError::InvalidValueType),
+            }
+        }
+    }
+
+    default_impl!(char, f32, f64, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
 }
 
 #[cfg(default_parsers_time)]
@@ -90,19 +125,36 @@ mod models {
         }
     }
 
-    #[async_trait]
-    impl ArgumentType for User {
-        async fn parse_argument<'a>(
-            ctx: &ArgumentParseContext<'a>,
-            raw: ArgumentParseRaw,
-        ) -> Result<Self, ArgumentParseError> {
-            let user = parse_id!(raw.value, UserId)
-                .to_user(&ctx.event_ctx.http)
-                .await
-                .map_err(ArgumentParseError::from)?;
-            Ok(user)
-        }
+    macro_rules! str_or_obj {
+        ($ty:ty, fn($ctx:ident, $value:ident) $from_str:tt) => {
+            #[async_trait]
+            impl ArgumentType for $ty {
+                async fn parse_argument<'a>(
+                    $ctx: &ArgumentParseContext<'a>,
+                    raw: ArgumentParseRaw,
+                ) -> Result<Self, ArgumentParseError> {
+                    match raw {
+                        ArgumentParseRaw::String($value) => $from_str,
+                        #[cfg(feature = "interactions")]
+                        ArgumentParseRaw::InteractionData(value @ serde_json::Value::Object(_)) => {
+                            Ok(serde_json::from_value(value)
+                                .map_err(|_| ArgumentParseError::InvalidValueFormat)?)
+                        },
+                        #[cfg(feature = "interactions")]
+                        _ => Err(ArgumentParseError::InvalidValueType),
+                    }
+                }
+            }
+        };
     }
+
+    str_or_obj!(User, fn(ctx, value) {
+        let user = parse_id!(value, UserId)
+            .to_user(&ctx.event_ctx.http)
+            .await
+            .map_err(ArgumentParseError::from)?;
+        Ok(user)
+    });
 
     #[async_trait]
     impl ArgumentType for Member {
@@ -111,8 +163,25 @@ mod models {
             raw: ArgumentParseRaw,
         ) -> Result<Self, ArgumentParseError> {
             if let Some(guild_id) = ctx.guild_id {
+                let user_id = match raw {
+                    ArgumentParseRaw::String(value) => parse_id!(value, UserId),
+                    #[cfg(feature = "interactions")]
+                    ArgumentParseRaw::InteractionData(serde_json::Value::Object(object)) => {
+                        parse_id!(
+                            object
+                                .get("id")
+                                .map(serde_json::Value::as_str)
+                                .flatten()
+                                .ok_or(ArgumentParseError::InvalidValueFormat)?
+                                .to_owned(),
+                            UserId
+                        )
+                    },
+                    #[cfg(feature = "interactions")]
+                    _ => return Err(ArgumentParseError::InvalidValueType),
+                };
                 let member = guild_id
-                    .member(&ctx.event_ctx.http, parse_id!(raw.value, UserId))
+                    .member(&ctx.event_ctx.http, user_id)
                     .await
                     .map_err(ArgumentParseError::from)?;
                 Ok(member)
@@ -122,19 +191,13 @@ mod models {
         }
     }
 
-    #[async_trait]
-    impl ArgumentType for Channel {
-        async fn parse_argument<'a>(
-            ctx: &ArgumentParseContext<'a>,
-            raw: ArgumentParseRaw,
-        ) -> Result<Self, ArgumentParseError> {
-            let channel = parse_id!(raw.value, ChannelId)
-                .to_channel(&ctx.event_ctx.http)
-                .await
-                .map_err(ArgumentParseError::from)?;
-            Ok(channel)
-        }
-    }
+    str_or_obj!(Channel, fn(ctx, value) {
+        let channel = parse_id!(value, ChannelId)
+            .to_channel(&ctx.event_ctx.http)
+            .await
+            .map_err(ArgumentParseError::from)?;
+        Ok(channel)
+    });
 
     #[async_trait]
     impl ArgumentType for GuildChannel {
@@ -152,32 +215,26 @@ mod models {
         }
     }
 
-    #[async_trait]
-    impl ArgumentType for Role {
-        async fn parse_argument<'a>(
-            ctx: &ArgumentParseContext<'a>,
-            raw: ArgumentParseRaw,
-        ) -> Result<Self, ArgumentParseError> {
-            if let Some(guild_id) = ctx.guild_id {
-                let role_id = parse_id!(raw.value, RoleId);
-                if let Some(role) = ctx
-                    .event_ctx
+    str_or_obj!(Role, fn(ctx, value) {
+        if let Some(guild_id) = ctx.guild_id {
+            let role_id = parse_id!(value, RoleId);
+            if let Some(role) = ctx
+                .event_ctx
                     .cache
                     .guild_field(&guild_id, |guild| guild.roles.get(&role_id).map(|r| r.clone()))
                     .await
                     .ok_or(ArgumentParseError::CannotParseInContext(
-                        "Guild not in cache".to_owned(),
+                            "Guild not in cache".to_owned(),
                     ))?
-                {
-                    Ok(role)
-                } else {
-                    Err(ArgumentParseError::CannotParseInContext(
-                        "Role does not exist in guild".to_owned(),
-                    ))
-                }
+            {
+                Ok(role)
             } else {
-                Err(ArgumentParseError::CannotParseInContext("Expected guild".to_owned()))
+                Err(ArgumentParseError::CannotParseInContext(
+                        "Role does not exist in guild".to_owned(),
+                ))
             }
+        } else {
+            Err(ArgumentParseError::CannotParseInContext("Expected guild".to_owned()))
         }
-    }
+    });
 }

--- a/polecen/src/arguments/parse.rs
+++ b/polecen/src/arguments/parse.rs
@@ -17,7 +17,25 @@ impl<'a> ArgumentParseContext<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArgumentParseRaw {
+    String(String),
+    #[cfg(feature = "interactions")]
+    InteractionData(serde_json::Value),
+}
+
+#[async_trait]
+pub trait ArgumentType
+where
+    Self: Sized,
+{
+    async fn parse_argument<'a>(
+        ctx: &ArgumentParseContext<'a>,
+        raw: ArgumentParseRaw,
+    ) -> Result<Self, ArgumentParseError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArgumentParseError {
     InvalidValueType,
     InvalidValueFormat,
@@ -40,20 +58,4 @@ impl fmt::Display for ArgumentParseError {
             },
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct ArgumentParseRaw {
-    pub value: String,
-}
-
-#[async_trait]
-pub trait ArgumentType
-where
-    Self: Sized,
-{
-    async fn parse_argument<'a>(
-        ctx: &ArgumentParseContext<'a>,
-        raw: ArgumentParseRaw,
-    ) -> Result<Self, ArgumentParseError>;
 }

--- a/polecen/src/command.rs
+++ b/polecen/src/command.rs
@@ -9,13 +9,20 @@ pub trait CommandArguments
 where
     Self: Sized,
 {
-    async fn read_arguments<'a, I>(
+    async fn read_str_arguments<'a, I>(
         args: I,
         position: u8,
         ctx: ArgumentParseContext<'a>,
     ) -> Result<Self, CommandArgumentsReadError>
     where
         I: Iterator<Item = &'a str> + Send;
+
+    #[cfg(feature = "interactions")]
+    async fn read_command_interaction_data<'a>(
+        args: serenity::model::interactions::ApplicationCommandInteractionData,
+        position: u8,
+        ctx: ArgumentParseContext<'a>,
+    ) -> Result<Self, CommandArgumentsReadError>;
 }
 
 #[derive(Clone, Debug)]

--- a/polecen/src/lib.rs
+++ b/polecen/src/lib.rs
@@ -6,6 +6,9 @@ pub mod macros;
 
 pub use async_trait::async_trait;
 pub use polecen_macros::*;
+#[cfg(feature = "interactions")]
+// export serde_json to use with macros
+pub use serde_json;
 
 #[cfg(feature = "macros")]
 pub use crate::macros::*;

--- a/polecen/src/macros.rs
+++ b/polecen/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! read_args {
     ($ty:ty, $args:expr, $ctx:expr, $guild_id:expr) => {
-        <$ty>::read_arguments(
+        <$ty>::read_str_arguments(
             $args,
             0,
             ::polecen::arguments::parse::ArgumentParseContext::new($ctx, $guild_id),


### PR DESCRIPTION
Implement interactions as an optional arguments source.

**Todo:**
- [x] Base implementation
- [x] Default parsers impls support
- [ ] Full read support
- [ ] Working example

**Changelogs:**
* New feature `interactions` on both lib and macros lib
* `ArgumentParseRaw` is now an enum
* Trait `CommandArguments` has a new function `read_command_interaction_data` (only with `interactions` feature)
* Renamed `read_arguments` to `read_str_arguments` for consistency
* Argument error `InvalidValueType` has now usages
* Re-export `serde_json` publicly in lib root so that macros can work without serde_json in current context